### PR TITLE
[feature] allow to choose jpg format

### DIFF
--- a/qtilesdialog.py
+++ b/qtilesdialog.py
@@ -68,7 +68,17 @@ class QTilesDialog(QDialog, Ui_Dialog):
 
         self.btnBrowse.clicked.connect(self.__selectOutput)
 
+        self.cmbFormat.activated.connect(self.formatChanged)
+
         self.manageGui()
+
+    def formatChanged(self):
+        if self.cmbFormat.currentText()=='JPG':
+            self.spnTransparency.setEnabled(False)
+            self.spnQuality.setEnabled(True)
+        else:
+            self.spnTransparency.setEnabled(True)
+            self.spnQuality.setEnabled(False)
 
     def manageGui(self):
         # populate combobox with layers
@@ -117,7 +127,9 @@ class QTilesDialog(QDialog, Ui_Dialog):
 
         self.spnTransparency.setValue(
                 self.settings.value('transparency', 255, type=int))
-        self.leSuffix.setText(self.settings.value('suffix', 'png'))
+        self.spnQuality.setValue(
+                self.settings.value('quality', 70, type=int))
+        self.cmbFormat.setCurrentIndex (self.settings.value('format', 0))
         self.chkAntialiasing.setChecked(
                 self.settings.value('enable_antialiasing', False, type=bool))
         self.chkTMSConvention.setChecked(
@@ -127,6 +139,8 @@ class QTilesDialog(QDialog, Ui_Dialog):
                 self.settings.value("write_mapurl", False, type=bool))
         self.chkWriteViewer.setChecked(
                 self.settings.value("write_viewer", False, type=bool))
+
+        self.formatChanged()
 
     def reject(self):
         QDialog.reject(self)
@@ -181,8 +195,9 @@ class QTilesDialog(QDialog, Ui_Dialog):
         self.settings.setValue('tileWidth', self.spnTileWidth.value())
         self.settings.setValue('tileHeight', self.spnTileHeight.value())
 
-        self.settings.setValue('suffix', self.leSuffix.text())
+        self.settings.setValue('format', self.cmbFormat.currentIndex ())
         self.settings.setValue('transparency', self.spnTransparency.value())
+        self.settings.setValue('quality', self.spnQuality.value())
         self.settings.setValue('enable_antialiasing',
                                self.chkAntialiasing.isChecked())
         self.settings.setValue('use_tms_filenames',
@@ -228,7 +243,8 @@ class QTilesDialog(QDialog, Ui_Dialog):
                 self.spnTileWidth.value(),
                 self.spnTileHeight.value(),
                 self.spnTransparency.value(),
-                self.leSuffix.text(),
+                self.spnQuality.value(),
+                self.cmbFormat.currentText(),
                 fileInfo,
                 self.leRootDir.text(),
                 self.chkAntialiasing.isChecked(),

--- a/tilingthread.py
+++ b/tilingthread.py
@@ -49,7 +49,7 @@ class TilingThread(QThread):
     processInterrupted = pyqtSignal()
 
     def __init__(self, layers, extent, minZoom, maxZoom, width, height, transp,
-                 suffix, outputPath, rootDir, antialiasing, tmsConvention,
+                 quality, format, outputPath, rootDir, antialiasing, tmsConvention,
                  mapUrl, viewer):
         QThread.__init__(self, QThread.currentThread())
         self.mutex = QMutex()
@@ -70,7 +70,8 @@ class TilingThread(QThread):
         self.antialias = antialiasing
         self.tmsConvention = tmsConvention
 
-        self.suffix = suffix
+        self.format = format
+        self.quality = quality
         self.mapurl = mapUrl
         self.viewer = viewer
 
@@ -249,7 +250,7 @@ class TilingThread(QThread):
         self.painter.end()
 
         # save image
-        self.writer.writeTile(tile, self.image, self.suffix)
+        self.writer.writeTile(tile, self.image, self.format, self.quality)
 
 
 class MyTemplate(Template):

--- a/ui/qtilesdialogbase.ui
+++ b/ui/qtilesdialogbase.ui
@@ -229,42 +229,63 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="6" column="0" colspan="3">
            <widget class="QCheckBox" name="chkAntialiasing">
             <property name="text">
              <string>Make lines appear less jagged at the expence of some drawing performance</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="7" column="0" colspan="3">
            <widget class="QCheckBox" name="chkTMSConvention">
             <property name="text">
              <string>Use TMS tiles convention (Slippy Map by default)</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="3">
+          <item row="8" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteMapurl">
             <property name="text">
              <string>Write .mapurl file</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0" colspan="3">
+          <item row="9" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteViewer">
             <property name="text">
              <string>Write Leaflet-based viewer</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QComboBox" name="cmbFormat">
+            <item>
+             <property name="text">
+              <string>PNG</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>JPG</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Background transparency</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
+          <item row="4" column="1">
            <widget class="QSpinBox" name="spnTransparency">
             <property name="maximum">
              <number>255</number>
@@ -274,15 +295,32 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_7">
             <property name="text">
-             <string>Suffix</string>
+             <string>Quality</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="leSuffix"/>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spnQuality">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>(0-100)</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/writers.py
+++ b/writers.py
@@ -40,11 +40,11 @@ class DirectoryWriter:
         self.output = outputPath
         self.rootDir = rootDir
 
-    def writeTile(self, tile, image, suffix):
+    def writeTile(self, tile, image, format, quality):
         path = '%s/%s/%s' % (self.rootDir, tile.z, tile.x)
         dirPath = '%s/%s' % (self.output.absoluteFilePath(), path)
         QDir().mkpath(dirPath)
-        image.save('%s/%s.%s' % (dirPath, tile.y, suffix), 'PNG')
+        image.save('%s/%s.%s' % (dirPath, tile.y, format.lower()), format, quality)
 
     def finalize(self):
         pass
@@ -63,11 +63,11 @@ class ZipWriter:
         self.tempFileName = self.tempFile.fileName()
         self.tempFile.close()
 
-    def writeTile(self, tile, image, suffix):
+    def writeTile(self, tile, image, format, quality):
         path = '%s/%s/%s' % (self.rootDir, tile.z, tile.x)
 
-        image.save(self.tempFileName, 'PNG')
-        tilePath = '%s/%s.%s' % (path, tile.y, suffix)
+        image.save(self.tempFileName, format, quality)
+        tilePath = '%s/%s.%s' % (path, tile.y, format.lower())
         self.zipFile.write(
             unicode(self.tempFileName), unicode(tilePath).encode('utf8'))
 
@@ -88,10 +88,10 @@ class MBTilesWriter:
         optimize_connection(self.cursor)
         mbtiles_setup(self.cursor)
 
-    def writeTile(self, tile, image, suffix):
+    def writeTile(self, tile, image, format, quality):
         data = QByteArray()
         buff = QBuffer(data)
-        image.save(buff, 'PNG')
+        image.save(buff, format, quality)
 
         self.cursor.execute('''INSERT INTO tiles(zoom_level, tile_column,
             tile_row, tile_data) VALUES (?, ?, ?, ?);''',


### PR DESCRIPTION
Hi !

First of all : Thanks a lot for your plugin !!

PNG is great for big uniform areas (vector-style maps), but poor for more complex images (satellite-style maps). For such images. with reasonable quality (around 80), tile size drops from around 160kb to 25kb.

So I implemented possibility to choose JPG format to export.

![tojpg](https://cloud.githubusercontent.com/assets/1894106/3256338/2817b422-f217-11e3-9f72-16252948f754.png)

This PR replaces the "suffix" (not sure what this was good for?) line edit by a "format" combobox. The suffix is then automatically set by the format.
It adds a "quality" spinbox (0-100), which is enabled only for the jpg format. The transparency spinbox is disabled when jpg format is chosen.

/!\ IMPORTANT BEFORE MERGE /!\
I don't know the MBTile format at all, and didn't test it.
I'm not sure if it depends on the png format or not. If so, this PR breaks it, since it also stores the data as JPG in the sqlite table.
I found some references to PNG in mbutils.py, but the parts using it seemed unused.
