### PR TITLE
fix not working with python 3.10

### DIFF
--- a/tilingthread.py
+++ b/tilingthread.py
@@ -214,7 +214,7 @@ class TilingThread(QThread):
         image = QImage(self.settings.outputSize(), QImage.Format_ARGB32)
         image.fill(Qt.transparent)
 
-        dpm = self.settings.outputDpi() / 25.4 * 1000
+        dpm = int(round(self.settings.outputDpi() / (25.4 * 1000)))
         image.setDotsPerMeterX(dpm)
         image.setDotsPerMeterY(dpm)
 
@@ -299,7 +299,7 @@ class TilingThread(QThread):
         image = QImage(self.settings.outputSize(), QImage.Format_ARGB32)
         image.fill(Qt.transparent)
 
-        dpm = self.settings.outputDpi() / 25.4 * 1000
+        dpm = int(round(self.settings.outputDpi() / (25.4 * 1000))
         image.setDotsPerMeterX(dpm)
         image.setDotsPerMeterY(dpm)
 


### PR DESCRIPTION
As suggested by https://github.com/friederschueler in  https://github.com/nextgis/qgis_qtiles/issues/118#issuecomment-1363334510 

On python 3.10 it says:

   TypeError: setDotsPerMeterX(self, a0: int): argument 1 has unexpected type 'float'

seems that other packages are suffering with the same: https://github.com/etetoolkit/ete/issues/616